### PR TITLE
Upgrade "aws-sdk" dependency to version 3.x

### DIFF
--- a/lib/yle/aws/role.rb
+++ b/lib/yle/aws/role.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'shellwords'
 
 require 'yle/aws/role/accounts'

--- a/yle-aws-role.gemspec
+++ b/yle-aws-role.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['asu']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 2.6'
+  spec.add_dependency 'aws-sdk-core', '~> 3.0'
   spec.add_dependency 'slop', '~> 4.4'
 
   spec.add_development_dependency 'bundler', '~> 1.13'


### PR DESCRIPTION
Reduces the amount of dependency code, as we only need a tiny part of the AWS SDK.

Upgrade guide if a depending project also depends on aws-sdk:
https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/