### PR TITLE
Fix invocation when command is not specified

### DIFF
--- a/lib/yle/aws/role/cli.rb
+++ b/lib/yle/aws/role/cli.rb
@@ -91,11 +91,12 @@ module Yle
         end
 
         def command
-          @command ||= [shell]
+          @command = shell if @command.empty?
+          @command
         end
 
         def shell
-          shell = ENV.fetch('SHELL', 'bash')
+          shell = default_shell
 
           if !opts[:quiet]
             puts "Executing shell '#{shell}' with the assumed role"
@@ -104,6 +105,10 @@ module Yle
           end
 
           [shell]
+        end
+
+        def default_shell
+          ENV.fetch('SHELL', 'bash')
         end
       end
     end

--- a/spec/yle/aws/role/cli_spec.rb
+++ b/spec/yle/aws/role/cli_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'yle/aws/role/cli'
+
+describe Yle::AWS::Role::Cli do
+  subject(:cli) { described_class.new(argv) }
+
+  let(:argv) { %w[112233445566 --role foo --quiet].concat(command) }
+  let(:command) { [] }
+
+  describe '#command' do
+    subject { cli.command }
+
+    context 'when not given in command line' do
+      context 'when SHELL is defined' do
+        before { ENV['SHELL'] = '/usr/bin/myshell' }
+        it { is_expected.to eq(['/usr/bin/myshell']) }
+      end
+
+      context 'when SHELL is not defined' do
+        before { ENV.delete('SHELL') }
+        it { is_expected.to eq(['bash']) }
+      end
+    end
+
+    context 'when given in command line' do
+      let(:command) { %w[-- some_cmd arg1] }
+      it { is_expected.to eq(%w[some_cmd arg1]) }
+    end
+  end
+end


### PR DESCRIPTION
The `@command` is always defined, but is an empty array if no command line args are given.