### PR TITLE
Update Ruby version in the Travis build matrix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
 
 Metrics/BlockLength:
   Exclude:
@@ -30,5 +34,8 @@ Style/GuardClause:
 Style/NegatedIf:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
 cache: bundler
 
-before_install:
-  # Workaround for https://github.com/travis-ci/travis-ci/issues/8969
-  - gem update --system
-
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in the gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/asu
+++ b/bin/asu
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require 'bundler/setup' if File.exist? File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist? File.expand_path('../Gemfile', __dir__)
 require 'yle/aws/role/cli'
 
 cli = Yle::AWS::Role::Cli.new(ARGV)

--- a/lib/yle-aws-role.rb
+++ b/lib/yle-aws-role.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'yle/aws/role'

--- a/lib/yle/aws/role.rb
+++ b/lib/yle/aws/role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws-sdk-core'
 require 'shellwords'
 
@@ -49,9 +51,9 @@ module Yle
         raise Errors::AssumeRoleError, 'Role name not specified' if !@role_name
 
         @credentials = Aws::AssumeRoleCredentials.new(
-          role_arn: role_arn,
+          role_arn:          role_arn,
           role_session_name: session_name,
-          duration_seconds: duration
+          duration_seconds:  duration
         ).credentials
       rescue Aws::STS::Errors::ServiceError,
              Aws::Errors::MissingCredentialsError => e

--- a/lib/yle/aws/role/accounts.rb
+++ b/lib/yle/aws/role/accounts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Yle
   module AWS
     class Role
@@ -39,8 +41,8 @@ module Yle
           aliases.keys.select { |key| matcher =~ key }.min_by(&:length)
         end
 
-        def alias_matcher(s)
-          pattern = s.gsub(/([^^])(?=[^$])/, '\1.*')
+        def alias_matcher(id_or_alias)
+          pattern = id_or_alias.gsub(/([^^])(?=[^$])/, '\1.*')
           Regexp.new(pattern)
         end
       end

--- a/lib/yle/aws/role/cli.rb
+++ b/lib/yle/aws/role/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'slop'
 
 require 'yle/aws/role'

--- a/lib/yle/aws/role/config.rb
+++ b/lib/yle/aws/role/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module Yle

--- a/lib/yle/aws/role/errors.rb
+++ b/lib/yle/aws/role/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Yle
   module AWS
     class Role

--- a/lib/yle/aws/role/version.rb
+++ b/lib/yle/aws/role/version.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Yle
   module AWS
     class Role
-      VERSION = '2.0.2.dev'.freeze
+      VERSION = '2.0.2.dev'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)

--- a/spec/yle/aws/role/accounts_spec.rb
+++ b/spec/yle/aws/role/accounts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yle/aws/role/accounts'
 
@@ -33,9 +35,9 @@ describe Yle::AWS::Role::Accounts do
     context 'without aliases' do
       let(:aliases) do
         {
-          'foo' => '123456789012',
-          'foo-bar' => '234567890123',
-          'baz' => '987654321098',
+          'foo'       => '123456789012',
+          'foo-bar'   => '234567890123',
+          'baz'       => '987654321098',
           'barbapapa' => '876543210987'
         }
       end

--- a/spec/yle/aws/role/cli_spec.rb
+++ b/spec/yle/aws/role/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yle/aws/role/cli'
 

--- a/spec/yle/aws/role/config_spec.rb
+++ b/spec/yle/aws/role/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yle/aws/role/config'
 

--- a/spec/yle/aws/role_spec.rb
+++ b/spec/yle/aws/role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Yle::AWS::Role do

--- a/yle-aws-role.gemspec
+++ b/yle-aws-role.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'yle/aws/role/version'
 


### PR DESCRIPTION
- Add Ruby 2.6.0
- Drop Ruby 2.2
- Update versions 2.3-2.5
- Upgrade Rubocop Rules for 2.3+ and fix also new rules
- Remove workaround for a fixed Travis issue