### PR TITLE
Update development dependencies and tested Ruby versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
@@ -10,11 +10,11 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'spec/**/*'
 
-Metrics/ClassLength:
+Layout/LineLength:
+  Max: 100
   Severity: warning
 
-Metrics/LineLength:
-  Max: 100
+Metrics/ClassLength:
   Severity: warning
 
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.6.0
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
+  - 2.7.0
+  - 2.6.5
+  - 2.5.7
+  - 2.4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 cache: bundler
 
+before_install:
+  # Install Bundler v2 as Travis uses v1.x in Ruby <2.7
+  - gem update --system
+  - gem install bundler
+
 rvm:
   - 2.6.0
   - 2.5.3

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Yleisradio Oy
+Copyright (c) 2016-2020 Yleisradio Oy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/yle/aws/role/cli.rb
+++ b/lib/yle/aws/role/cli.rb
@@ -45,7 +45,7 @@ module Yle
           @account_name = @opts.args.shift
           @command = @opts.args
         rescue Slop::Error => e
-          STDERR.puts e
+          warn e
           exit 64
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
@@ -54,12 +54,12 @@ module Yle
           return if opts[:list]
 
           if !account_name
-            STDERR.puts opts
+            warn opts
             exit 64
           end
 
           if !(opts[:role] || Role.default_role_name)
-            STDERR.puts 'Role name must be passed with `--role` or set in the config'
+            warn 'Role name must be passed with `--role` or set in the config'
             exit 64
           end
         end
@@ -85,18 +85,18 @@ module Yle
         def run_command
           assume_role do
             ret = system(*command)
-            STDERR.puts "Failed to execute '#{command.first}'" if ret.nil?
+            warn "Failed to execute '#{command.first}'" if ret.nil?
             exit(1) if !ret
           end
         end
 
         def assume_role
           Role.assume_role(account_name, opts[:role], opts[:duration]) do |role|
-            STDERR.puts("Assumed role #{role.name}") if !opts[:quiet]
+            warn("Assumed role #{role.name}") if !opts[:quiet]
             yield role
           end
         rescue Errors::AssumeRoleError => e
-          STDERR.puts e
+          warn e
           exit 1
         end
 

--- a/lib/yle/aws/role/config.rb
+++ b/lib/yle/aws/role/config.rb
@@ -29,7 +29,7 @@ module Yle
         def self.load_yaml(path)
           (path && File.exist?(path) && YAML.load_file(path)) || {}
         rescue StandardError
-          STDERR.puts("WARN: Failed to load or parse configuration from '#{path}'")
+          warn("WARN: Failed to load or parse configuration from '#{path}'")
           {}
         end
 

--- a/yle-aws-role.gemspec
+++ b/yle-aws-role.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-core', '~> 3.0'
   spec.add_dependency 'slop', '~> 4.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
 end


### PR DESCRIPTION
Add Ruby 2.7 to Travis tests, and drop support for 2.3. Also update development dependencies and Rubocop issues.